### PR TITLE
#22 Fix

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,17 @@
 ---
-- name: TIMESCALEDB | Be sure timescaledb key is present
-  apt_key:
+
+- name: TIMESCALEDB | Download timescaledb key
+  get_url:
     url: "{{ timescaledb_deb_key }}"
-    state: present
+    dest: /tmp/timescaledb.gpg.key
+    mode: '0644'
+
+- name: TIMESCALEDB | Import timescaledb key
+  command: "gpg --dearmor -o /etc/apt/trusted.gpg.d/timescaledb.gpg /tmp/timescaledb.gpg.key"
+  args:
+    creates: /etc/apt/trusted.gpg.d/timescaledb.gpg
+  become: true
+  changed_when: false
 
 - name: TIMESCALEDB | Be sure timescaledb repo packages configured
   apt_repository:


### PR DESCRIPTION
remove apt_key for Debian 13 (Trixie) and Ubuntu 24.04 compatibility\n\nCloses #22. Replaced apt_key with get_url and gpg --dearmor to support Debian 13 (Trixie) and Ubuntu 24.04, where apt-key is no longer available.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;
* Add "idealista/benders" as reviewer

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
